### PR TITLE
feat: 优化缩略图使其强匹配鼠标悬浮点

### DIFF
--- a/src/components/XPlayer/components/Thumbnail/index.vue
+++ b/src/components/XPlayer/components/Thumbnail/index.vue
@@ -1,19 +1,19 @@
 <template>
-	<div 
+	<div
 		class="preview-container"
 		v-show="visible"
-		:style="{ 
+		:style="{
 			left: `${position}%`,
 			transform: `translateX(${previewTransform}px)`
 		}"
 	>
 		<div class="thumbnail-container">
-			<canvas 
+			<canvas
 				ref="thumbnailCanvas"
 				:width="width"
 				:height="height"
 			></canvas>
-			<div class="thumbnail-loading" v-if="tasks.length > 0">
+			<div class="thumbnail-loading" v-if="thumb.loading">
 				<LoadingBar />
 			</div>
 		</div>
@@ -24,7 +24,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onUnmounted, ref, shallowRef, watch } from "vue";
+import { debounce } from "lodash";
+import { computed, reactive, ref, watch } from "vue";
 import { usePlayerContext } from "../../hooks/usePlayer";
 import { formatTime } from "../../utils/time";
 import LoadingBar from "./LoadingBar.vue";
@@ -41,10 +42,8 @@ const { rootProps, source } = usePlayerContext();
 const { onThumbnailRequest } = rootProps;
 const thumbnailCanvas = ref<HTMLCanvasElement | null>(null);
 const ctx = computed(() => thumbnailCanvas.value?.getContext("2d"));
-const currentThumbnail = ref<ImageBitmap | null>(null);
-const tasks = ref<number[]>([]);
-const width = computed(() => currentThumbnail.value?.width ?? 320);
-const height = computed(() => currentThumbnail.value?.height ?? 180);
+const width = computed(() => thumb.renderImage?.width ?? 320);
+const height = computed(() => thumb.renderImage?.height ?? 180);
 
 // 计算预览容器的位移，防止超出边界
 const previewTransform = computed(() => {
@@ -67,32 +66,79 @@ const previewTransform = computed(() => {
 	return -(thumbnailWidth / 2);
 });
 
-// 更新缩略图
+const timeBlurRange = 15;
+const timeBlurOffset = (timeBlurRange - 1) / 2;
+const timeBlur = computed(
+	() => Math.floor(props.time / timeBlurRange) * timeBlurRange + timeBlurOffset,
+);
+
+const thumb = reactive({
+	lastHoverTime: -1,
+	lastRequestTime: -1,
+	renderImage: null as ImageBitmap | null,
+	loading: computed(
+		(): boolean =>
+			thumb.lastRequestTime >= 0 &&
+			thumb.lastRequestTime === thumb.lastHoverTime,
+	),
+});
+
+const requestThumbnail = debounce(async () => {
+	if (thumb.lastHoverTime === -1) return;
+
+	const requestTime = thumb.lastHoverTime;
+	thumb.lastRequestTime = requestTime;
+	const image = await onThumbnailRequest("Must", requestTime);
+	if (!image) return;
+
+	if (requestTime === thumb.lastHoverTime) {
+		thumb.lastRequestTime = -1;
+		thumb.renderImage = image;
+	}
+}, 0.5 * 1000);
+
 watch(
-	() => props.time,
-	async (newTime) => {
-		if (onThumbnailRequest) {
-			tasks.value.push(newTime);
-			currentThumbnail.value = await onThumbnailRequest(newTime);
-			tasks.value = tasks.value.filter((task) => task !== newTime);
+	() => [props.visible, timeBlur.value],
+	async () => {
+		if (!props.visible) {
+			thumb.lastHoverTime = -1;
+			thumb.renderImage = null;
+			return;
+		}
+
+		if (!onThumbnailRequest) return;
+
+		thumb.lastHoverTime = timeBlur.value;
+		thumb.renderImage = null;
+
+		const cacheImage = await onThumbnailRequest("Cache", thumb.lastHoverTime); // 尝试从缓存中取, 其实是同步返回
+		if (cacheImage) {
+			thumb.renderImage = cacheImage;
+		} else {
+			requestThumbnail();
 		}
 	},
 );
 
 // 绘制缩略图
-watch(currentThumbnail, (newVal) => {
-	if (thumbnailCanvas.value && ctx.value) {
-		requestAnimationFrame(() => {
-			ctx.value.fillRect(0, 0, width.value, height.value);
-			if (newVal) {
-				ctx.value.drawImage(newVal, 0, 0, width.value, height.value);
-			}
-		});
-	}
-});
+watch(
+	() => thumb.renderImage,
+	(newVal) => {
+		if (thumbnailCanvas.value && ctx.value) {
+			requestAnimationFrame(() => {
+				ctx.value.fillRect(0, 0, width.value, height.value);
+				if (newVal) {
+					ctx.value.drawImage(newVal, 0, 0, width.value, height.value);
+				}
+			});
+		}
+	},
+);
 
 watch([source.list], () => {
-	currentThumbnail.value = null;
+	thumb.lastHoverTime = -1;
+	thumb.lastRequestTime = -1;
+	thumb.renderImage = null;
 });
 </script>
 
@@ -130,4 +176,4 @@ watch([source.list], () => {
 	height: 2px;
 	background: rgba(0, 0, 0, 0.3);
 }
-</style> 
+</style>

--- a/src/components/XPlayer/components/Thumbnail/index.vue
+++ b/src/components/XPlayer/components/Thumbnail/index.vue
@@ -66,12 +66,6 @@ const previewTransform = computed(() => {
 	return -(thumbnailWidth / 2);
 });
 
-const timeBlurRange = 15;
-const timeBlurOffset = (timeBlurRange - 1) / 2;
-const timeBlur = computed(
-	() => Math.floor(props.time / timeBlurRange) * timeBlurRange + timeBlurOffset,
-);
-
 const thumb = reactive({
 	lastHoverTime: -1,
 	lastRequestTime: -1,
@@ -98,7 +92,7 @@ const requestThumbnail = debounce(async () => {
 }, 0.5 * 1000);
 
 watch(
-	() => [props.visible, timeBlur.value],
+	() => [props.visible, props.time],
 	async () => {
 		if (!props.visible) {
 			thumb.lastHoverTime = -1;
@@ -108,7 +102,7 @@ watch(
 
 		if (!onThumbnailRequest) return;
 
-		thumb.lastHoverTime = timeBlur.value;
+		thumb.lastHoverTime = props.time;
 		thumb.renderImage = null;
 
 		const cacheImage = await onThumbnailRequest("Cache", thumb.lastHoverTime); // 尝试从缓存中取, 其实是同步返回

--- a/src/components/XPlayer/index.vue
+++ b/src/components/XPlayer/index.vue
@@ -1,5 +1,5 @@
 <template>
-	<div 
+	<div
 		class="x-player"
 		:class="{ 'is-fullscreen': fullscreen.isFullscreen.value }"
 		@mousemove="handleRootMouseMove"
@@ -8,11 +8,11 @@
 		<!-- 播放器容器 -->
 		<div class="player-container">
 			<!-- 视频容器 -->
-			<div 
+			<div
 				class="video-container"
 			>
 				<!-- 视频元素 -->
-				<video 
+				<video
 					ref="videoElement"
 					:key="source.videoKey.value"
 					:poster="source.current.value?.poster"
@@ -43,7 +43,7 @@
 				<Loading :show="playing.isLoading.value" />
 
 				<!-- 视频遮罩 -->
-				<div 
+				<div
 					class="video-mask"
 					@click="playing.togglePlay"
 					@dblclick="fullscreen.toggleFullscreen"
@@ -53,7 +53,7 @@
 			</div>
 		</div>
 		<!-- 弹出层容器 -->
-		<div 
+		<div
 			class="portal-container"
 			:ref="portalContext.container"
 		></div>
@@ -72,7 +72,10 @@ import PlayAnimation from "./components/PlayAnimation/index.vue";
 
 export interface XPlayerProps {
 	sources: Ref<VideoSource[]>;
-	onThumbnailRequest?: (time: number) => Promise<ImageBitmap>;
+	onThumbnailRequest?: (
+		type: "Cache" | "Must",
+		time: number,
+	) => Promise<ImageBitmap | null>;
 	subtitles: Ref<Subtitle[] | null>;
 	loadingSubtitles: Ref<boolean>;
 	onSubtitleChange?: (subtitle: Subtitle | null) => void;

--- a/src/pages/video/index.vue
+++ b/src/pages/video/index.vue
@@ -14,7 +14,7 @@
 				<!-- <button class="page-mpv-play" @click="handleMpvPlay">MPV 本地播放器 Beta</button> -->
 				<div class="page-flow">
 					<FileInfo :fileInfo="DataFileInfo" />
-					<MovieInfo 
+					<MovieInfo
 						:movieInfos="DataMovieInfo"
 					/>
 					<div class="page-footer">
@@ -23,10 +23,10 @@
 				</div>
 			</div>
 			<div class="page-sider">
-				<Playlist class="page-sider-playlist" 
-					:pickCode="params.pickCode.value" 
-					:playlist="DataPlaylist" 
-					@play="handlePlay" 
+				<Playlist class="page-sider-playlist"
+					:pickCode="params.pickCode.value"
+					:playlist="DataPlaylist"
+					@play="handlePlay"
 				/>
 			</div>
 		</div>
@@ -92,7 +92,6 @@ const handlePlay = async (item: Entity.PlaylistItem) => {
 	});
 	params.getParams();
 	DataVideoSources.cleanup();
-	DataThumbnails.cleanup();
 	DataSubtitles.execute(0, params.pickCode.value, null);
 	DataMovieInfo.value.javBusState.execute(0, null);
 	DataMovieInfo.value.javDBState.execute(0, null);
@@ -150,7 +149,6 @@ onMounted(async () => {
 
 onUnmounted(() => {
 	DataVideoSources.cleanup();
-	DataThumbnails.cleanup();
 });
 </script>
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,0 +1,29 @@
+import { type WatchStopHandle, watchEffect } from "vue";
+
+const wait = (checkFunc: () => boolean) => {
+	return new Promise<void>((resolve) => {
+		let stopOnFirst = false;
+
+		let stopWatch: WatchStopHandle | undefined = undefined;
+		stopWatch = watchEffect(() => {
+			const flag = checkFunc();
+			if (flag) {
+				resolve();
+
+				if (stopWatch) {
+					stopWatch();
+				} else {
+					stopOnFirst = true;
+				}
+			}
+		});
+
+		if (stopOnFirst) {
+			stopWatch();
+		}
+	});
+};
+
+export const util = {
+	wait,
+};


### PR DESCRIPTION
修改缩略图展示相关逻辑
~~1. 增加时间模糊 15秒共享一个缩略图~~
2. 确保展示的缩略图一定匹配当前鼠标查看时间点
3. 鼠标在进度条上快速移动时 仅加载鼠标最后停留的视频片段
4. 增加同一视频片段同时获取时去除重复加载

PS: 仅修改逻辑 未动UI 建议可修改加载时的loading效果