### PR TITLE
fix: unavailable function on Safari

### DIFF
--- a/src/pages/magnet/index.ts
+++ b/src/pages/magnet/index.ts
@@ -41,7 +41,12 @@ export function registerMagnetTaskHandler() {
  * 注册磁力链接协议处理程序
  */
 export function registerMagnetProtocolHandler() {
-  navigator.registerProtocolHandler('magnet', '/web/lixian/master/magnet/?url=%s')
+  if (navigator.registerProtocolHandler) {
+    navigator.registerProtocolHandler('magnet', '/web/lixian/master/magnet/?url=%s')
+  }
+  else {
+    console.warn('此浏览器不支持注册协议处理程序')
+  }
 }
 
 /**


### PR DESCRIPTION
Safari浏览器中不支持Navigator：registerProtocolHandler() 方法，会导致脚本启动失败。因此添加一个检查，不支持时跳过，可以让其他功能正常运行。

经测试，macOS / Safari 26.0.1 + Tampermonkey 5.4.6229 可以正常使用其他功能。