### PR TITLE
refactor: remove glass border gradient effect

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -37,53 +37,6 @@
 
 @utility app-glass-border {
   border: 1px solid rgba(255, 255, 255, 0.15);
-
-  &::after {
-    position: absolute;
-    top: -1px;
-    left: -1px;
-    width: calc(100% + 2px);
-    height: calc(100% + 2px);
-    content: '';
-    border-radius: inherit;
-    background: linear-gradient(
-      to right bottom,
-      rgba(255, 255, 255, 0.5) 0%,
-      transparent 40%,
-      transparent 60%,
-      rgba(255, 255, 255, 0.3) 100%
-    );
-    padding: 2px;
-    -webkit-mask:
-      linear-gradient(#fff 0 100%) content-box,
-      linear-gradient(#fff 0 100%);
-    -webkit-mask-composite: xor;
-    z-index: 10;
-    pointer-events: none;
-  }
-  &::before {
-    position: absolute;
-    top: -0.5px;
-    left: -0.5px;
-    width: calc(100% + 1px);
-    height: calc(100% + 1px);
-    content: '';
-    border-radius: inherit;
-    background: linear-gradient(
-      to right bottom,
-      rgba(255, 255, 255, 0.2) 0%,
-      transparent 70%,
-      transparent 80%,
-      rgba(255, 255, 255, 0.1) 100%
-    );
-    padding: 1px;
-    -webkit-mask:
-      linear-gradient(#fff 0 100%) content-box,
-      linear-gradient(#fff 0 100%);
-    -webkit-mask-composite: xor;
-    pointer-events: none;
-    z-index: 10;
-  }
 }
 
 @utility app-bg-gradient-glass {


### PR DESCRIPTION
## Summary
- Removed the gradient border effect from `app-glass-border` utility class
- The `-webkit-mask-composite: xor` property was becoming ineffective after production build due to CSS minification reordering properties

## Root Cause
The `-webkit-mask` shorthand property was overriding `-webkit-mask-composite: xor` after build minification changed the property order, causing the gradient border effect to disappear.

## Changes
- Removed `::before` and `::after` pseudo-elements from `app-glass-border`
- Kept only the base `border: 1px solid rgba(255, 255, 255, 0.15)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)