### PR TITLE
fix: #298 restore missing folder link feature

### DIFF
--- a/src/pages/home/FileListMod/FileItemMod/folderLink.ts
+++ b/src/pages/home/FileListMod/FileItemMod/folderLink.ts
@@ -1,0 +1,44 @@
+import { NORMAL_URL_115 } from '../../../../constants/115'
+import { FileType } from '../../types'
+import { FileItemModBase } from './base'
+
+/**
+ * FileItemModFolderLink 文件夹链接修改
+ * @description 修改文件夹 a 标签链接（支持鼠标中键新标签打开）
+ */
+export class FileItemModFolderLink extends FileItemModBase {
+  get fileNameNode() {
+    return this.itemNode.querySelector('.file-name')
+  }
+
+  get fileAtagNode() {
+    return this.fileNameNode?.querySelector('a') as HTMLAnchorElement | null
+  }
+
+  onLoad() {
+    if (this.itemInfo.attributes.file_type !== FileType.folder) {
+      return
+    }
+
+    this.modFolderATagLink()
+  }
+
+  onDestroy() {
+    // noop
+  }
+
+  private modFolderATagLink() {
+    const aNode = this.fileAtagNode
+    if (!aNode) {
+      return
+    }
+
+    if (aNode.href.includes('javascript:;')) {
+      const newHref = new URL(
+        `/?cid=${this.itemInfo.attributes.cate_id}&offset=0&tab=&mode=wangpan`,
+        NORMAL_URL_115,
+      ).href
+      aNode.href = newHref
+    }
+  }
+}

--- a/src/pages/home/FileListMod/index.ts
+++ b/src/pages/home/FileListMod/index.ts
@@ -9,11 +9,13 @@ import { FileItemModClickPlay } from './FileItemMod/clickPlay'
 import { FileItemModDownload } from './FileItemMod/download'
 import { FileItemModExtInfo } from './FileItemMod/extInfo'
 import { FileItemModExtMenu } from './FileItemMod/extMenu'
+import { FileItemModFolderLink } from './FileItemMod/folderLink'
 import { FileItemModVideoCover } from './FileItemMod/videoCover'
 import { FileListScrollHistory } from './scrollHistory'
 import './index.css'
 
 const itemMods = [
+  FileItemModFolderLink,
   FileItemModExtInfo,
   FileItemModActressInfo,
   FileItemModVideoCover,


### PR DESCRIPTION
## Summary
- Restore missing folder link feature that was lost in previous refactoring
- Add `FileItemModFolderLink` modifier to handle folder anchor links
- Convert `javascript:;` links to proper 115 drive URLs (format: `/?cid={cate_id}&offset=0&tab=&mode=wangpan`)
- Enable opening folders in new tabs via middle mouse click

## Files Changed
- **src/pages/home/FileListMod/FileItemMod/folderLink.ts** (new): New modifier for folder link handling
- **src/pages/home/FileListMod/index.ts**: Register the new folder link modifier

## Test plan
- [x] Test clicking on folder names with left mouse button
- [x] Test opening folders in new tabs with middle mouse button
- [x] Verify folder links navigate to correct directory
- [x] Check that file items are not affected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)