### PR TITLE
fix: file move not working in production build

### DIFF
--- a/src/utils/core115/core115.ts
+++ b/src/utils/core115/core115.ts
@@ -1,4 +1,5 @@
 import type { Core as CoreType, MockjQueryObject } from './core115.types'
+import { unsafeWindow } from '$'
 
 /** 115 官方资源 URL */
 const OFFICIAL_ASSETS = [
@@ -64,8 +65,10 @@ export async function load() {
 
   // 等待 Core 对象加载
   await new Promise<void>((resolve) => {
+    /** 使用 unsafeWindow */
+    const win = getPageWindow()
     const checkCore = () => {
-      if (typeof window !== 'undefined' && (window as any).Core) {
+      if (typeof win !== 'undefined' && (win as any).Core) {
         resolve()
       }
       else {
@@ -88,7 +91,7 @@ export async function load() {
  * 在 Tampermonkey 环境中，直接使用 jQuery 的 AJAX 功能进行 API 调用
  */
 function initUDataAPI() {
-  const win = window as any
+  const win = getPageWindow()
   const $ = win.$
   const Core = win.Core
 
@@ -126,11 +129,12 @@ function initUDataAPI() {
 
 /**
  * 获取页面上下文中的 Core 对象
- * 注意：115 SDK 运行在页面上下文中，需要通过 window 访问
+ * 注意：115 SDK 运行在页面上下文中，需要通过 unsafeWindow 访问
  */
 function getPageWindow(): any {
-  // 115 SDK 注入到页面上下文，需要访问原始的 window
-  return window
+  // 115 SDK 注入到页面上下文，需要访问 unsafeWindow
+  // 不能使用 window（Tampermonkey 沙箱），否则无法访问 Core 对象
+  return unsafeWindow
 }
 
 /**


### PR DESCRIPTION
## Problem
The file move feature (`TreeDG.Show()`) was not working in production build, even though it worked correctly in the dev environment. When clicking the move button in the video player page, the dialog never appeared, although the network panel showed that the SDK resources were being loaded.

## Root Cause
Tampermonkey sandbox isolation issue:

- **SDK Context**: The 115 SDK scripts are injected into the page context via `document.head.appendChild(script)`, so they run in the **page's real window**
- **Code Context**: Our code runs in the **Tampermonkey sandbox** with an isolated `window` object
- **The Bug**: `getPageWindow()` was returning `window` (sandbox) instead of `unsafeWindow` (page), and `load()` function was checking `window.Core` instead of `unsafeWindow.Core`

## Solution
Modified `src/utils/core115/core115.ts`:

1. **Import unsafeWindow**: Added `import { unsafeWindow } from '$'`
2. **Update getPageWindow()**: Changed from `return window` to `return unsafeWindow`
3. **Update load()**: Changed from checking `window.Core` to checking `win.Core` where `win = getPageWindow()`
4. **Update initUDataAPI()**: Changed from using `window` directly to using `getPageWindow()`

## Testing
- ✅ Dev environment: Works
- ✅ Production build: Works (confirmed after fix)

## Related
- Fixes issue described in `fix-move-file.md`