### PR TITLE
fix: upgrade hls.js to v1.6.15 to resolve audio distortion issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "blueimp-md5": "^2.19.0",
     "dayjs": "^1.11.13",
     "glob-to-regexp": "^0.4.1",
-    "hls.js": "^1.5.20",
+    "hls.js": "^1.6.15",
     "iconify-icon": "^3.0.0",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1
       hls.js:
-        specifier: ^1.5.20
-        version: 1.5.20
+        specifier: ^1.6.15
+        version: 1.6.15
       iconify-icon:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1831,8 +1831,8 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
-  hls.js@1.5.20:
-    resolution: {integrity: sha512-uu0VXUK52JhihhnN/MVVo1lvqNNuhoxkonqgO3IpjvQiGpJBdIXMGkofjQb/j9zvV7a1SW8U9g1FslWx/1HOiQ==}
+  hls.js@1.6.15:
+    resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -4655,7 +4655,7 @@ snapshots:
 
   he@1.2.0: {}
 
-  hls.js@1.5.20: {}
+  hls.js@1.6.15: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary

- Upgrade hls.js from v1.5.20 to v1.6.15 to fix audio distortion issue that may occur during HLS playback

## Root Cause

Related to Chromium issue: https://issues.chromium.org/issues/428740130

## Changes

- `hls.js`: ^1.5.20 → ^1.6.15
- Updated `pnpm-lock.yaml` with new dependency resolution

## Test plan

- [x] Play HLS videos and verify no audio distortion occurs
- [x] Test on Chrome 130+ and 115Browser 35+

🤖 Generated with [Claude Code](https://claude.com/claude-code)