### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yalc.lock
 
 # vitest
 coverage
+
+# git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary

Add \`.worktrees/\` to \`.gitignore\` to prevent accidental commits of git worktree directories.

## Changes

- Add \`.worktrees/\` ignore rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)