### PR TITLE
修复：避免动态 import 导致暴力猴加载失败

### DIFF
--- a/apps/monkey/src/pages/home/components/ExtVideoCover/index.vue
+++ b/apps/monkey/src/pages/home/components/ExtVideoCover/index.vue
@@ -37,6 +37,7 @@
 
 <script setup lang="ts">
 import PhotoSwipeLightbox from 'photoswipe/lightbox'
+import PhotoSwipe from 'photoswipe'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import LoadingError from '@/components/LoadingError/index.vue'
 import { useSmartVideoCover } from '@/hooks/useVideoCover'
@@ -122,7 +123,7 @@ function initPhotoSwipe() {
       alt: '视频封面',
     })),
     showHideAnimationType: 'fade',
-    pswpModule: () => import('photoswipe'),
+    pswpModule: () => Promise.resolve(PhotoSwipe),
     mouseMovePan: true,
     initialZoomLevel: 'fit',
     secondaryZoomLevel: 2,

--- a/apps/monkey/src/pages/video/components/MovieInfo/index.vue
+++ b/apps/monkey/src/pages/video/components/MovieInfo/index.vue
@@ -227,6 +227,7 @@
 <script lang="ts" setup>
 import type { useDataMovieInfo } from '@/pages/video/data/useDataMovieInfo'
 import PhotoSwipeLightbox from 'photoswipe/lightbox'
+import PhotoSwipe from 'photoswipe'
 import { computed, nextTick, ref, watch } from 'vue'
 import Empty from '@/components/empty/Empty.vue'
 import LoadingError from '@/components/LoadingError/index.vue'
@@ -322,7 +323,7 @@ watch(movieInfoThumb, async () => {
   lightbox.value = new PhotoSwipeLightbox({
     gallery: movieInfoThumb.value,
     children: 'a',
-    pswpModule: () => import('photoswipe'),
+    pswpModule: () => Promise.resolve(PhotoSwipe),
     mouseMovePan: true,
     initialZoomLevel: 'fit',
     wheelToZoom: true,

--- a/apps/monkey/src/pages/video/index.ts
+++ b/apps/monkey/src/pages/video/index.ts
@@ -1,8 +1,9 @@
 import { GM_addStyle, GM_cookie } from '$'
-import { createApp, defineAsyncComponent } from 'vue'
+import { createApp } from 'vue'
 import { DL_URL_115, NORMAL_URL_115 } from '@/constants/115'
 import mainStyles from '@/styles/main.css?inline'
 import { core115 } from '@/utils/core115'
+import VideoPage from './index.vue'
 
 function resetDocument() {
   document.body.style.backgroundColor = '#000'
@@ -110,11 +111,7 @@ export async function videoPage() {
   }
   document.head.append(style)
 
-  createApp(
-    defineAsyncComponent({
-      loader: () => import('./index.vue'),
-    }),
-  ).mount('#my-app')
+  createApp(VideoPage).mount('#my-app')
 
   core115.load()
 }


### PR DESCRIPTION
此前提过的暴力猴无法加载问题，系 Proxy 执行 ownKeys 时返回重复键名。全量打包可以避开，但不够好，这次换用 GPT 5.2 Extra High 尝试，找到了更好的修复办法。

改动说明：
1. PhotoSwipe 改为静态导入，避免动态 import 触发沙箱全局枚举
2. 视频页入口改为静态导入，减少运行时加载风险

影响范围：
- 仅涉及前端资源加载方式
- 不改变业务逻辑

测试情况：
- 本地构建通过
- 暴力猴脚本加载正常