### PR TITLE
feat(aria2): 新增 Aria2 RPC 导出功能（支持文件夹递归下载）

### DIFF
--- a/.changeset/aria2-export.md
+++ b/.changeset/aria2-export.md
@@ -1,0 +1,12 @@
+---
+"@115master/monkey": minor
+---
+
+新增 Aria2 RPC 导出功能：
+
+- 文件列表每行在 115 原生下载按钮旁增加「推送 Aria2」按钮
+- 支持配置多个 RPC 预设，按数量自适应（0=引导/1=单按钮/≥2=下拉）
+- **支持文件夹递归下载**：自动遍历子目录，在 aria2 落盘时保留目录结构
+- 独立设置面板：RPC 列表、下载路径、递归间隔、SHA1 校验、UA/Referer/自定义 Headers
+- 新增通用 MasterToast 组件，支持 info / success / error / loading（带进度更新）
+- 自动注入 115 的 Cookie / UA / Referer 到 aria2，绕过下载鉴权

--- a/apps/monkey/package.json
+++ b/apps/monkey/package.json
@@ -54,6 +54,7 @@
     "lodash": "^4.17.21",
     "m3u8-parser": "^7.2.0",
     "mitt": "^3.0.1",
+    "nanoid": "^5.1.9",
     "photoswipe": "^5.4.4",
     "tailwindcss": "^4.1.7",
     "vue": "^3.5.13"

--- a/apps/monkey/src/components/Aria2SettingsDialog/RpcListEditor.vue
+++ b/apps/monkey/src/components/Aria2SettingsDialog/RpcListEditor.vue
@@ -1,0 +1,101 @@
+<template>
+  <div :class="$style.wrap">
+    <div
+      v-for="(item, i) in items"
+      :key="item.id"
+      :class="$style.row"
+    >
+      <input
+        :value="item.name"
+        class="input input-bordered input-sm w-40"
+        placeholder="名称"
+        @input="update(i, 'name', ($event.target as HTMLInputElement).value)"
+      >
+      <input
+        :value="item.url"
+        class="input input-bordered input-sm flex-1"
+        placeholder="http://token:密钥@127.0.0.1:6800/jsonrpc"
+        @input="update(i, 'url', ($event.target as HTMLInputElement).value)"
+      >
+      <button class="btn btn-sm btn-ghost" @click="onTest(i)">
+        测试
+      </button>
+      <button class="btn btn-sm btn-ghost text-error" @click="remove(i)">
+        删除
+      </button>
+      <span v-if="testResults[item.id]" :class="$style.result">
+        {{ testResults[item.id] }}
+      </span>
+    </div>
+    <button class="btn btn-sm btn-primary self-start" @click="add">
+      + 添加 RPC
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Aria2RpcPreset } from '@/utils/aria2'
+import { nanoid } from 'nanoid'
+import { reactive, watch } from 'vue'
+import { testRpc } from '@/utils/aria2'
+
+const props = defineProps<{ modelValue: Aria2RpcPreset[] }>()
+const emit = defineEmits<{ (e: 'update:modelValue', v: Aria2RpcPreset[]): void }>()
+
+const items = reactive<Aria2RpcPreset[]>([...props.modelValue])
+const testResults = reactive<Record<string, string>>({})
+
+watch(() => props.modelValue, (next) => {
+  items.splice(0, items.length, ...next)
+}, { deep: true })
+
+function emitChange() {
+  emit('update:modelValue', JSON.parse(JSON.stringify(items)))
+}
+
+function update(i: number, k: 'name' | 'url', v: string) {
+  items[i][k] = v
+  emitChange()
+}
+
+function add() {
+  items.push({ id: nanoid(), name: '', url: '' })
+  emitChange()
+}
+
+function remove(i: number) {
+  items.splice(i, 1)
+  emitChange()
+}
+
+async function onTest(i: number) {
+  const item = items[i]
+  testResults[item.id] = '连接中...'
+  try {
+    const v = await testRpc(item.url)
+    testResults[item.id] = `v${v}`
+  }
+  catch (e) {
+    testResults[item.id] = e instanceof Error ? e.message : '失败'
+  }
+}
+</script>
+
+<style module>
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.result {
+  font-size: 12px;
+  color: #64748b;
+  margin-left: 4px;
+}
+</style>

--- a/apps/monkey/src/components/Aria2SettingsDialog/index.vue
+++ b/apps/monkey/src/components/Aria2SettingsDialog/index.vue
@@ -1,0 +1,140 @@
+<template>
+  <dialog ref="dialogRef" class="modal">
+    <div class="modal-box w-11/12 max-w-3xl">
+      <h3 class="font-bold text-lg mb-4">
+        Aria2 导出设置
+      </h3>
+
+      <div :class="$style.section">
+        <label class="label">RPC 列表</label>
+        <RpcListEditor v-model="form.rpcList" />
+      </div>
+
+      <div :class="$style.section">
+        <label class="label">下载路径（可选）</label>
+        <input
+          v-model="form.downloadPath"
+          class="input input-bordered w-full"
+          placeholder="绝对路径，对应 aria2 --dir"
+        >
+      </div>
+
+      <div :class="$style.section">
+        <label class="label">递归间隔（ms）</label>
+        <input
+          v-model.number="form.intervalMs"
+          type="number"
+          class="input input-bordered w-40"
+          min="0"
+        >
+      </div>
+
+      <div :class="$style.section">
+        <label class="label cursor-pointer justify-start gap-2">
+          <input
+            v-model="form.sha1Check"
+            type="checkbox"
+            class="checkbox checkbox-sm"
+          >
+          SHA1 校验
+        </label>
+      </div>
+
+      <div :class="$style.section">
+        <label class="label cursor-pointer justify-start gap-2">
+          <input
+            v-model="form.useBrowserUA"
+            type="checkbox"
+            class="checkbox checkbox-sm"
+          >
+          使用浏览器 UA
+        </label>
+        <input
+          v-model="form.userAgent"
+          class="input input-bordered w-full mt-2"
+          :disabled="form.useBrowserUA"
+          placeholder="自定义 User-Agent"
+        >
+      </div>
+
+      <div :class="$style.section">
+        <label class="label">Referer</label>
+        <input v-model="form.referer" class="input input-bordered w-full">
+      </div>
+
+      <div :class="$style.section">
+        <label class="label">自定义 Headers（每行 Key: Value）</label>
+        <textarea
+          v-model="form.extraHeaders"
+          class="textarea textarea-bordered w-full h-24"
+        />
+      </div>
+
+      <div class="modal-action">
+        <button class="btn" @click="onReset">
+          重置
+        </button>
+        <button class="btn btn-primary" @click="onApply">
+          应用
+        </button>
+        <button class="btn" @click="close">
+          关闭
+        </button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import type { Aria2Settings } from '@/utils/aria2'
+import { onMounted, onUnmounted, reactive, ref } from 'vue'
+import { ARIA2_DEFAULT_SETTINGS, aria2Events, readSettings, writeSettings } from '@/utils/aria2'
+import RpcListEditor from './RpcListEditor.vue'
+
+const dialogRef = ref<HTMLDialogElement | null>(null)
+const form = reactive<Aria2Settings>({ ...readSettings() })
+
+function refill() {
+  Object.assign(form, readSettings())
+  if (!form.userAgent)
+    form.userAgent = navigator.userAgent
+}
+
+function open() {
+  refill()
+  dialogRef.value?.showModal()
+}
+
+function close() {
+  dialogRef.value?.close()
+}
+
+function onApply() {
+  const cleaned: Aria2Settings = {
+    ...form,
+    rpcList: form.rpcList.filter(r => r.name.trim() && r.url.trim()),
+  }
+  writeSettings(cleaned)
+  close()
+}
+
+function onReset() {
+  Object.assign(form, ARIA2_DEFAULT_SETTINGS)
+}
+
+onMounted(() => {
+  aria2Events.on('aria2:open-settings', open)
+})
+onUnmounted(() => {
+  aria2Events.off('aria2:open-settings', open)
+})
+</script>
+
+<style module>
+.section {
+  margin-bottom: 16px;
+}
+</style>

--- a/apps/monkey/src/components/MasterToast/index.vue
+++ b/apps/monkey/src/components/MasterToast/index.vue
@@ -1,0 +1,66 @@
+<template>
+  <div :class="$style.container">
+    <TransitionGroup name="toast">
+      <div
+        v-for="t in toastQueue"
+        :key="t.id"
+        role="alert"
+        :class="[$style.toast, $style[t.kind]]"
+      >
+        <span
+          v-if="t.kind === 'loading'"
+          class="loading loading-spinner loading-sm" :class="[$style.icon]"
+        />
+        <span>{{ t.message }}</span>
+      </div>
+    </TransitionGroup>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toastQueue } from './toast'
+</script>
+
+<style module>
+.container {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 99999;
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  color: white;
+  font-size: 14px;
+  min-width: 220px;
+  max-width: 400px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+}
+
+.info {
+  background: #3b82f6;
+}
+.success {
+  background: #16a34a;
+}
+.error {
+  background: #dc2626;
+}
+.loading {
+  background: #475569;
+}
+
+.icon {
+  flex-shrink: 0;
+}
+</style>

--- a/apps/monkey/src/components/MasterToast/toast.ts
+++ b/apps/monkey/src/components/MasterToast/toast.ts
@@ -1,0 +1,74 @@
+import { reactive } from 'vue'
+
+export type ToastKind = 'info' | 'success' | 'error' | 'loading'
+
+export interface ToastItem {
+  id: number
+  kind: ToastKind
+  message: string
+}
+
+export interface LoadingHandle {
+  update: (msg: string) => void
+  success: (msg?: string) => void
+  error: (msg?: string) => void
+  dismiss: () => void
+}
+
+const DURATION: Record<Exclude<ToastKind, 'loading'>, number> = {
+  info: 3000,
+  success: 3000,
+  error: 6000,
+}
+
+export const toastQueue = reactive<ToastItem[]>([])
+
+let seq = 0
+function nextId() {
+  return ++seq
+}
+
+function remove(id: number) {
+  const i = toastQueue.findIndex(t => t.id === id)
+  if (i >= 0)
+    toastQueue.splice(i, 1)
+}
+
+function push(kind: Exclude<ToastKind, 'loading'>, message: string): void {
+  const id = nextId()
+  toastQueue.push({ id, kind, message })
+  setTimeout(() => remove(id), DURATION[kind])
+}
+
+export const toast = {
+  info: (msg: string) => push('info', msg),
+  success: (msg: string) => push('success', msg),
+  error: (msg: string) => push('error', msg),
+  loading(message: string): LoadingHandle {
+    const id = nextId()
+    toastQueue.push({ id, kind: 'loading', message })
+    const findIdx = () => toastQueue.findIndex(t => t.id === id)
+    return {
+      update(msg) {
+        const i = findIdx()
+        if (i >= 0)
+          toastQueue[i].message = msg
+      },
+      success(msg) {
+        const i = findIdx()
+        if (i >= 0)
+          toastQueue[i] = { id, kind: 'success', message: msg ?? message }
+        setTimeout(() => remove(id), DURATION.success)
+      },
+      error(msg) {
+        const i = findIdx()
+        if (i >= 0)
+          toastQueue[i] = { id, kind: 'error', message: msg ?? message }
+        setTimeout(() => remove(id), DURATION.error)
+      },
+      dismiss() {
+        remove(id)
+      },
+    }
+  },
+}

--- a/apps/monkey/src/icons/index.ts
+++ b/apps/monkey/src/icons/index.ts
@@ -18,3 +18,9 @@ export const ICON_RIGHT = 'bytesize:chevron-right'
 export const ICON_LEFT = 'bytesize:chevron-left'
 // 移动文件
 export const ICON_DRIVE_FILE_MOVE = 'material-symbols:drive-file-move-outline'
+// Aria2 推送
+export const ICON_ARIA2 = 'material-symbols:cloud-download-rounded'
+// 设置齿轮
+export const ICON_ARIA2_SETTINGS = 'material-symbols:settings-rounded'
+// 下拉箭头
+export const ICON_CHEVRON_DOWN = 'material-symbols:keyboard-arrow-down-rounded'

--- a/apps/monkey/src/pages/home/FileListMod/FileItemMod/aria2Push.ts
+++ b/apps/monkey/src/pages/home/FileListMod/FileItemMod/aria2Push.ts
@@ -1,0 +1,206 @@
+import type { Aria2RpcPreset } from '@/utils/aria2'
+import { toast } from '@/components/MasterToast/toast'
+import { FileListType, FileType } from '@/pages/home/types'
+import { aria2Events, pushFile, pushFolder, readSettings, subscribeSettings } from '@/utils/aria2'
+import { is115Browser } from '@/utils/platform'
+import { FileItemModBase } from './base'
+
+/**
+ * FileItemMod — 行内 Aria2 推送按钮
+ * 三态：0 个 RPC 预设 → 配置引导；1 个 → 单按钮；≥2 → 下拉
+ */
+export class FileItemModAria2Push extends FileItemModBase {
+  private container: HTMLElement | null = null
+  private unsubscribe: (() => void) | null = null
+
+  get fileOprNode() {
+    return (
+      this.itemNode.querySelector<HTMLElement>('.file-opr')
+      ?? this.itemNode.querySelector<HTMLElement>('.file-opt')
+    )
+  }
+
+  get isFolder() {
+    return this.itemInfo.attributes.file_type === FileType.folder
+  }
+
+  onLoad() {
+    if (is115Browser)
+      return
+    if (this.itemInfo.fileListType === FileListType.grid)
+      return
+    if (!this.fileOprNode)
+      return
+
+    this.render()
+    this.unsubscribe = subscribeSettings(() => this.render())
+  }
+
+  onDestroy() {
+    this.container?.remove()
+    this.container = null
+    this.unsubscribe?.()
+    this.unsubscribe = null
+  }
+
+  private render() {
+    this.container?.remove()
+    this.container = document.createElement('span')
+    this.container.style.cssText
+      = 'display:inline-flex;align-items:center;margin-right:8px;position:relative;z-index:1000;pointer-events:all;'
+
+    const list = readSettings().rpcList
+    if (list.length === 0) {
+      this.container.appendChild(this.buildConfigButton())
+    }
+    else if (list.length === 1) {
+      this.container.appendChild(this.buildSingleButton(list[0]))
+    }
+    else {
+      this.container.appendChild(this.buildDropdown(list))
+    }
+
+    this.fileOprNode?.prepend(this.container)
+  }
+
+  private buildConfigButton(): HTMLElement {
+    const a = document.createElement('a')
+    a.href = 'javascript:void(0)'
+    a.textContent = '⚙ 配置 Aria2'
+    a.title = '尚未配置 Aria2 RPC，点击打开设置'
+    a.style.cssText
+      = 'color:#888;padding:2px 6px;border:1px dashed #aaa;border-radius:4px;font-size:12px;'
+    a.addEventListener('mousedown', (e) => {
+      e.preventDefault()
+      e.stopImmediatePropagation()
+      aria2Events.emit('aria2:open-settings')
+    })
+    return a
+  }
+
+  private buildSingleButton(preset: Aria2RpcPreset): HTMLElement {
+    const a = document.createElement('a')
+    a.href = 'javascript:void(0)'
+    a.textContent = `⇩ ${preset.name}`
+    a.title = `推送到 Aria2：${preset.name}`
+    a.style.cssText = 'padding:2px 6px;font-size:12px;'
+    a.addEventListener('mousedown', async (e) => {
+      e.preventDefault()
+      e.stopImmediatePropagation()
+      await this.handlePush(preset)
+    })
+    return a
+  }
+
+  private buildDropdown(presets: Aria2RpcPreset[]): HTMLElement {
+    const wrap = document.createElement('span')
+    wrap.style.cssText = 'position:relative;display:inline-block;'
+
+    const trigger = document.createElement('a')
+    trigger.href = 'javascript:void(0)'
+    trigger.textContent = '⇩ Aria2 ▾'
+    trigger.style.cssText = 'padding:2px 6px;font-size:12px;'
+
+    const menu = document.createElement('div')
+    menu.style.cssText
+      = 'position:absolute;top:100%;left:0;background:#fff;border:1px solid #ddd;border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.1);padding:4px 0;min-width:140px;display:none;z-index:1001;'
+
+    for (const p of presets) {
+      const item = document.createElement('a')
+      item.href = 'javascript:void(0)'
+      item.textContent = p.name
+      item.style.cssText
+        = 'display:block;padding:6px 12px;font-size:12px;color:#333;text-decoration:none;'
+      item.addEventListener('mouseenter', () => {
+        item.style.background = '#f1f5f9'
+      })
+      item.addEventListener('mouseleave', () => {
+        item.style.background = ''
+      })
+      item.addEventListener('mousedown', async (e) => {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        menu.style.display = 'none'
+        await this.handlePush(p)
+      })
+      menu.appendChild(item)
+    }
+
+    const divider = document.createElement('div')
+    divider.style.cssText = 'border-top:1px solid #eee;margin:4px 0;'
+    menu.appendChild(divider)
+
+    const settingsItem = document.createElement('a')
+    settingsItem.href = 'javascript:void(0)'
+    settingsItem.textContent = '⚙ 设置'
+    settingsItem.style.cssText
+      = 'display:block;padding:6px 12px;font-size:12px;color:#666;text-decoration:none;'
+    settingsItem.addEventListener('mousedown', (e) => {
+      e.preventDefault()
+      e.stopImmediatePropagation()
+      menu.style.display = 'none'
+      aria2Events.emit('aria2:open-settings')
+    })
+    menu.appendChild(settingsItem)
+
+    wrap.addEventListener('mouseenter', () => {
+      menu.style.display = 'block'
+    })
+    wrap.addEventListener('mouseleave', () => {
+      menu.style.display = 'none'
+    })
+
+    wrap.appendChild(trigger)
+    wrap.appendChild(menu)
+    return wrap
+  }
+
+  private async handlePush(rpc: Aria2RpcPreset) {
+    const attrs = this.itemInfo.attributes
+    if (this.isFolder) {
+      /** 文件夹的「自身 id」在 115 DOM 里是 cate_id；cid 是所在的父目录 */
+      const folderCid = attrs.cate_id || attrs.cid
+      if (!folderCid) {
+        toast.error('无法获取文件夹 ID')
+        return
+      }
+      const handle = toast.loading(`正在获取文件列表... 0`)
+      try {
+        const result = await pushFolder({
+          cid: folderCid,
+          rootPath: attrs.title,
+          rpc,
+          onListProgress: walked => handle.update(`正在获取文件列表... ${walked}`),
+          onPushProgress: (done, total, failed) =>
+            handle.update(`推送中 ${done}/${total}${failed ? `（失败 ${failed}）` : ''}`),
+        })
+        if (result.failed === 0) {
+          handle.success(`已推送 ${result.done} 个文件`)
+        }
+        else {
+          handle.error(`已推送 ${result.done}，失败 ${result.failed}`)
+        }
+      }
+      catch (e) {
+        handle.error(`推送失败：${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+    else {
+      const h = toast.loading(`推送 ${attrs.title}...`)
+      try {
+        await pushFile(
+          {
+            pickCode: attrs.pick_code,
+            name: attrs.title,
+            sha1: attrs.sha1,
+          },
+          rpc,
+        )
+        h.success('推送成功')
+      }
+      catch (e) {
+        h.error(`推送失败：${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+  }
+}

--- a/apps/monkey/src/pages/home/FileListMod/index.ts
+++ b/apps/monkey/src/pages/home/FileListMod/index.ts
@@ -5,6 +5,7 @@ import { appLogger } from '@/utils/logger'
 import { isReload } from '@/utils/route'
 import { FileItemModLoader } from './FileItemLoader'
 import { FileItemModActressInfo } from './FileItemMod/actressInfo'
+import { FileItemModAria2Push } from './FileItemMod/aria2Push'
 import { FileItemModClickPlay } from './FileItemMod/clickPlay'
 import { FileItemModDownload } from './FileItemMod/download'
 import { FileItemModExtInfo } from './FileItemMod/extInfo'
@@ -20,6 +21,7 @@ const itemMods = [
   FileItemModActressInfo,
   FileItemModVideoCover,
   FileItemModExtMenu,
+  FileItemModAria2Push,
   FileItemModClickPlay,
   FileItemModDownload,
 ]

--- a/apps/monkey/src/pages/home/index.ts
+++ b/apps/monkey/src/pages/home/index.ts
@@ -1,3 +1,6 @@
+import { createApp, h } from 'vue'
+import Aria2SettingsDialog from '@/components/Aria2SettingsDialog/index.vue'
+import MasterToast from '@/components/MasterToast/index.vue'
 import { registerMagnetTaskHandler } from '@/pages/magnet'
 import { ModManager } from './BaseMod'
 import FileListMod from './FileListMod'
@@ -36,6 +39,22 @@ class HomePage {
       new TopFilePathMod(),
       new TopHeaderMod(),
     ])
+    this.mountToast()
+    this.mountAria2SettingsDialog()
+  }
+
+  /** 挂载 MasterToast 到主文档 body */
+  private mountToast(): void {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    createApp({ render: () => h(MasterToast) }).mount(host)
+  }
+
+  /** 挂载 Aria2 设置对话框到主文档 body */
+  private mountAria2SettingsDialog(): void {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    createApp({ render: () => h(Aria2SettingsDialog) }).mount(host)
   }
 }
 

--- a/apps/monkey/src/utils/aria2/__tests__/config.test.ts
+++ b/apps/monkey/src/utils/aria2/__tests__/config.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { readSettings, subscribeSettings, writeSettings } from '../config'
+import { ARIA2_DEFAULT_SETTINGS } from '../types'
+
+const store = new Map<string, unknown>()
+
+vi.mock('$', () => ({
+  GM_getValue: (k: string) => store.get(k),
+  GM_setValue: (k: string, v: unknown) => { store.set(k, v) },
+}))
+
+beforeEach(() => {
+  store.clear()
+})
+
+describe('aria2 config', () => {
+  it('首次读取返回默认值', () => {
+    expect(readSettings()).toEqual(ARIA2_DEFAULT_SETTINGS)
+  })
+
+  it('写入后读取一致', () => {
+    writeSettings({ intervalMs: 500, downloadPath: '/tmp' })
+    const s = readSettings()
+    expect(s.intervalMs).toBe(500)
+    expect(s.downloadPath).toBe('/tmp')
+    expect(s.rpcList).toEqual([])
+  })
+
+  it('写入后 GM 存储包含完整字段', () => {
+    writeSettings({ intervalMs: 500 })
+    expect(store.get('ARIA2_SETTINGS')).toMatchObject({
+      ...ARIA2_DEFAULT_SETTINGS,
+      intervalMs: 500,
+    })
+  })
+
+  it('subscribeSettings 在 writeSettings 后被调用', () => {
+    const cb = vi.fn()
+    subscribeSettings(cb)
+    writeSettings({ downloadPath: '/a' })
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb.mock.calls[0][0].downloadPath).toBe('/a')
+  })
+
+  it('subscribeSettings 返回 unsubscribe 可取消', () => {
+    const cb = vi.fn()
+    const un = subscribeSettings(cb)
+    un()
+    writeSettings({ downloadPath: '/b' })
+    expect(cb).not.toHaveBeenCalled()
+  })
+})

--- a/apps/monkey/src/utils/aria2/__tests__/headers.test.ts
+++ b/apps/monkey/src/utils/aria2/__tests__/headers.test.ts
@@ -1,0 +1,60 @@
+import type { Aria2Settings } from '../types'
+import { describe, expect, it } from 'vitest'
+import { buildAria2Headers } from '../headers'
+import { ARIA2_DEFAULT_SETTINGS } from '../types'
+
+const base: Aria2Settings = {
+  ...ARIA2_DEFAULT_SETTINGS,
+  userAgent: 'custom-ua',
+  referer: 'https://115.com',
+}
+
+describe('buildAria2Headers', () => {
+  it('useBrowserUA=true 使用传入的 browserUserAgent', () => {
+    const h = buildAria2Headers({
+      settings: { ...base, useBrowserUA: true },
+      cookie: 'a=1',
+      browserUserAgent: 'browser-ua',
+    })
+    expect(h).toContain('User-Agent: browser-ua')
+  })
+
+  it('useBrowserUA=false 使用 settings.userAgent', () => {
+    const h = buildAria2Headers({
+      settings: { ...base, useBrowserUA: false },
+      cookie: 'a=1',
+      browserUserAgent: 'browser-ua',
+    })
+    expect(h).toContain('User-Agent: custom-ua')
+  })
+
+  it('包含 Referer 和 Cookie', () => {
+    const h = buildAria2Headers({
+      settings: base,
+      cookie: 'UID=xxx; CID=yyy',
+      browserUserAgent: 'b',
+    })
+    expect(h).toContain('Referer: https://115.com')
+    expect(h).toContain('Cookie: UID=xxx; CID=yyy')
+  })
+
+  it('extraHeaders 每行一条，空行和无冒号行忽略', () => {
+    const h = buildAria2Headers({
+      settings: { ...base, extraHeaders: 'X-A: 1\n\nnot-a-header\nX-B: 2' },
+      cookie: '',
+      browserUserAgent: 'b',
+    })
+    expect(h).toContain('X-A: 1')
+    expect(h).toContain('X-B: 2')
+    expect(h).not.toContain('not-a-header')
+  })
+
+  it('cookie 为空时不输出 Cookie 行', () => {
+    const h = buildAria2Headers({
+      settings: base,
+      cookie: '',
+      browserUserAgent: 'b',
+    })
+    expect(h.some(line => line.startsWith('Cookie:'))).toBe(false)
+  })
+})

--- a/apps/monkey/src/utils/aria2/__tests__/rpc.test.ts
+++ b/apps/monkey/src/utils/aria2/__tests__/rpc.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('$', () => ({
+  GM_info: { userAgentData: { brands: [] } },
+  GM_xmlhttpRequest: vi.fn(),
+  GM_getValue: vi.fn(),
+  GM_setValue: vi.fn(),
+}))
+
+const { buildAddUriPayload, parseRpcUrl } = await import('../rpc')
+
+describe('parseRpcUrl', () => {
+  it('无认证', () => {
+    const r = parseRpcUrl('http://localhost:6800/jsonrpc')
+    expect(r.endpoint).toBe('http://localhost:6800/jsonrpc')
+    expect(r.auth).toBeUndefined()
+    expect(r.options).toEqual({})
+  })
+
+  it('token 认证', () => {
+    const r = parseRpcUrl('http://token:mysecret@localhost:6800/jsonrpc')
+    expect(r.endpoint).toBe('http://localhost:6800/jsonrpc')
+    expect(r.auth).toEqual({ mode: 'token', token: 'token:mysecret' })
+  })
+
+  it('basic 认证', () => {
+    const r = parseRpcUrl('http://alice:p%40ss@host:6800/jsonrpc')
+    expect(r.endpoint).toBe('http://host:6800/jsonrpc')
+    expect(r.auth?.mode).toBe('basic')
+    expect(r.auth && r.auth.mode === 'basic' && r.auth.header).toBe(
+      `Basic ${btoa('alice:p@ss')}`,
+    )
+  })
+
+  it('fragment options', () => {
+    const r = parseRpcUrl(
+      'http://localhost:6800/jsonrpc#split=10&max-connection-per-server=5',
+    )
+    expect(r.options).toEqual({
+      'split': '10',
+      'max-connection-per-server': '5',
+    })
+  })
+
+  it('fragment 空值视为 enabled', () => {
+    const r = parseRpcUrl('http://localhost:6800/jsonrpc#continue')
+    expect(r.options).toEqual({ continue: 'enabled' })
+  })
+})
+
+describe('buildAddUriPayload', () => {
+  const base = {
+    url: 'https://dl.115.com/file.mp4',
+    out: 'foo/bar.mp4',
+    headers: ['User-Agent: ua', 'Referer: https://115.com'],
+    downloadPath: '',
+    sha1: undefined as string | undefined,
+    sha1Check: false,
+    fragmentOptions: {} as Record<string, string>,
+  }
+
+  it('最小载荷', () => {
+    const parsed = parseRpcUrl('http://localhost:6800/jsonrpc')
+    const payload = buildAddUriPayload(parsed, base)
+    expect(payload.jsonrpc).toBe('2.0')
+    expect(payload.method).toBe('aria2.addUri')
+    expect(typeof payload.id).toBe('number')
+    expect(payload.params[0]).toEqual(['https://dl.115.com/file.mp4'])
+    const opts = payload.params[1] as Record<string, unknown>
+    expect(opts.out).toBe('foo/bar.mp4')
+    expect(opts.header).toEqual(base.headers)
+    expect(opts.dir).toBeUndefined()
+    expect(opts.checksum).toBeUndefined()
+  })
+
+  it('token 认证前置 params', () => {
+    const parsed = parseRpcUrl('http://token:xxx@localhost:6800/jsonrpc')
+    const payload = buildAddUriPayload(parsed, base)
+    expect(payload.params[0]).toBe('token:xxx')
+    expect(payload.params[1]).toEqual(['https://dl.115.com/file.mp4'])
+  })
+
+  it('basic 认证不改 params', () => {
+    const parsed = parseRpcUrl('http://a:b@localhost:6800/jsonrpc')
+    const payload = buildAddUriPayload(parsed, base)
+    expect(payload.params[0]).toEqual(['https://dl.115.com/file.mp4'])
+  })
+
+  it('downloadPath 映射为 dir', () => {
+    const parsed = parseRpcUrl('http://localhost:6800/jsonrpc')
+    const payload = buildAddUriPayload(parsed, {
+      ...base,
+      downloadPath: '/downloads',
+    })
+    const opts = payload.params[payload.params.length - 1] as Record<
+      string,
+      unknown
+    >
+    expect(opts.dir).toBe('/downloads')
+  })
+
+  it('sha1Check+sha1 填充 checksum', () => {
+    const parsed = parseRpcUrl('http://localhost:6800/jsonrpc')
+    const payload = buildAddUriPayload(parsed, {
+      ...base,
+      sha1: 'abc',
+      sha1Check: true,
+    })
+    const opts = payload.params[payload.params.length - 1] as Record<
+      string,
+      unknown
+    >
+    expect(opts.checksum).toBe('sha-1=abc')
+  })
+
+  it('sha1Check=true 但 sha1 缺失 → 不加 checksum', () => {
+    const parsed = parseRpcUrl('http://localhost:6800/jsonrpc')
+    const payload = buildAddUriPayload(parsed, {
+      ...base,
+      sha1: undefined,
+      sha1Check: true,
+    })
+    const opts = payload.params[payload.params.length - 1] as Record<
+      string,
+      unknown
+    >
+    expect(opts.checksum).toBeUndefined()
+  })
+
+  it('fragmentOptions 合并到末尾 options', () => {
+    const parsed = parseRpcUrl('http://localhost:6800/jsonrpc#split=10')
+    const payload = buildAddUriPayload(parsed, {
+      ...base,
+      fragmentOptions: parsed.options,
+    })
+    const opts = payload.params[payload.params.length - 1] as Record<
+      string,
+      unknown
+    >
+    expect(opts.split).toBe('10')
+  })
+})

--- a/apps/monkey/src/utils/aria2/__tests__/walker.test.ts
+++ b/apps/monkey/src/utils/aria2/__tests__/walker.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const getFiles = vi.fn()
+
+vi.mock('$', () => ({
+  GM_info: { userAgentData: { brands: [] } },
+  GM_xmlhttpRequest: vi.fn(),
+  GM_getValue: vi.fn(),
+  GM_setValue: vi.fn(),
+}))
+
+vi.mock('@/utils/drive115', () => ({
+  drive115: {
+    getFiles: (...args: unknown[]) => getFiles(...args),
+  },
+}))
+
+const { walkFolder } = await import('../walker')
+
+function mkFile(pc: string, n: string, sha = 's') {
+  return { pc, n, sha, s: 1 }
+}
+
+function mkDir(cid: string, n: string) {
+  return { cid, n }
+}
+
+describe('walkFolder', () => {
+  it('单层目录：两个文件', async () => {
+    getFiles.mockResolvedValueOnce({
+      state: true,
+      data: [mkFile('p1', 'a.mp4'), mkFile('p2', 'b.mp4')],
+      path: [{ name: 'root' }],
+    })
+    const out: unknown[] = []
+    for await (const e of walkFolder('100', 'root', 0)) out.push(e)
+    expect(out).toEqual([
+      { pickCode: 'p1', name: 'a.mp4', relPath: 'root', sha1: 's', size: 1 },
+      { pickCode: 'p2', name: 'b.mp4', relPath: 'root', sha1: 's', size: 1 },
+    ])
+  })
+
+  it('两层嵌套：根下有一个子目录和一个文件', async () => {
+    getFiles
+      .mockResolvedValueOnce({
+        state: true,
+        data: [mkFile('p1', 'a.mp4'), mkDir('200', 'sub')],
+        path: [{ name: 'root' }],
+      })
+      .mockResolvedValueOnce({
+        state: true,
+        data: [mkFile('p2', 'b.mp4')],
+        path: [{ name: 'root' }, { name: 'sub' }],
+      })
+    const out: unknown[] = []
+    for await (const e of walkFolder('100', 'root', 0)) out.push(e)
+    expect(out).toContainEqual({
+      pickCode: 'p1',
+      name: 'a.mp4',
+      relPath: 'root',
+      sha1: 's',
+      size: 1,
+    })
+    expect(out).toContainEqual({
+      pickCode: 'p2',
+      name: 'b.mp4',
+      relPath: 'root/sub',
+      sha1: 's',
+      size: 1,
+    })
+  })
+
+  it('失败 1 次后重试成功', async () => {
+    getFiles
+      .mockRejectedValueOnce(new Error('net'))
+      .mockResolvedValueOnce({
+        state: true,
+        data: [mkFile('p1', 'a.mp4')],
+        path: [{ name: 'root' }],
+      })
+    const out: unknown[] = []
+    for await (const e of walkFolder('100', 'root', 0)) out.push(e)
+    expect(out.length).toBe(1)
+  })
+
+  it('失败两次后抛出', async () => {
+    getFiles
+      .mockRejectedValueOnce(new Error('net1'))
+      .mockRejectedValueOnce(new Error('net2'))
+    await expect(async () => {
+      for await (const _ of walkFolder('100', 'root', 0)) {
+        /* drain */
+      }
+    }).rejects.toThrow()
+  })
+})

--- a/apps/monkey/src/utils/aria2/config.ts
+++ b/apps/monkey/src/utils/aria2/config.ts
@@ -1,0 +1,28 @@
+import type { Aria2Settings } from './types'
+import { GM_getValue, GM_setValue } from '$'
+import { ARIA2_DEFAULT_SETTINGS } from './types'
+
+const KEY = 'ARIA2_SETTINGS'
+
+type Subscriber = (next: Aria2Settings) => void
+const subscribers = new Set<Subscriber>()
+
+/** 读取完整设置（缺失字段填默认值） */
+export function readSettings(): Aria2Settings {
+  const raw = GM_getValue<Partial<Aria2Settings> | undefined>(KEY) ?? {}
+  return { ...ARIA2_DEFAULT_SETTINGS, ...raw }
+}
+
+/** 部分更新设置 */
+export function writeSettings(patch: Partial<Aria2Settings>): Aria2Settings {
+  const next = { ...readSettings(), ...patch }
+  GM_setValue(KEY, next)
+  subscribers.forEach(fn => fn(next))
+  return next
+}
+
+/** 订阅变更；返回 unsubscribe */
+export function subscribeSettings(cb: Subscriber): () => void {
+  subscribers.add(cb)
+  return () => subscribers.delete(cb)
+}

--- a/apps/monkey/src/utils/aria2/events.ts
+++ b/apps/monkey/src/utils/aria2/events.ts
@@ -1,0 +1,9 @@
+import mitt from 'mitt'
+
+// mitt 要求泛型参数兼容 Record<EventType, unknown>，interface 因无隐式索引签名无法满足
+// eslint-disable-next-line ts/consistent-type-definitions
+type Events = {
+  'aria2:open-settings': void
+}
+
+export const aria2Events = mitt<Events>()

--- a/apps/monkey/src/utils/aria2/headers.ts
+++ b/apps/monkey/src/utils/aria2/headers.ts
@@ -1,0 +1,26 @@
+import type { Aria2Settings } from './types'
+
+export function buildAria2Headers(input: {
+  settings: Aria2Settings
+  cookie: string
+  browserUserAgent: string
+}): string[] {
+  const { settings, cookie, browserUserAgent } = input
+  const ua = settings.useBrowserUA ? browserUserAgent : settings.userAgent
+  const out: string[] = []
+  if (ua)
+    out.push(`User-Agent: ${ua}`)
+  if (settings.referer)
+    out.push(`Referer: ${settings.referer}`)
+  if (cookie)
+    out.push(`Cookie: ${cookie}`)
+  if (settings.extraHeaders) {
+    settings.extraHeaders.split('\n').forEach((line) => {
+      const trimmed = line.trim()
+      if (trimmed && trimmed.includes(':')) {
+        out.push(trimmed)
+      }
+    })
+  }
+  return out
+}

--- a/apps/monkey/src/utils/aria2/index.ts
+++ b/apps/monkey/src/utils/aria2/index.ts
@@ -1,0 +1,95 @@
+import type { Aria2FileEntry, Aria2RpcPreset } from './types'
+import { drive115 } from '@/utils/drive115'
+import { appLogger } from '@/utils/logger'
+import { readSettings } from './config'
+import { buildAria2Headers } from './headers'
+import { getAria2Version, parseRpcUrl, sendAddUri } from './rpc'
+import { walkFolder } from './walker'
+
+const logger = appLogger.sub('Aria2')
+
+export { readSettings, subscribeSettings, writeSettings } from './config'
+export { aria2Events } from './events'
+export type { Aria2FileEntry, Aria2RpcPreset, Aria2Settings } from './types'
+export { ARIA2_DEFAULT_SETTINGS } from './types'
+
+/** 测试 RPC 连通性（返回版本号） */
+export async function testRpc(rpcUrl: string): Promise<string> {
+  return getAria2Version(rpcUrl)
+}
+
+/** 推送单文件 */
+export async function pushFile(file: {
+  pickCode: string
+  name: string
+  relPath?: string
+  sha1?: string
+}, rpc: Aria2RpcPreset): Promise<void> {
+  const settings = readSettings()
+  const download = await drive115.getFileDownloadUrl(file.pickCode)
+  const url = download?.url?.url
+  if (!url) {
+    throw new Error(`无法获取下载地址: ${file.name}`)
+  }
+  const headers = buildAria2Headers({
+    settings,
+    cookie: document.cookie,
+    browserUserAgent: navigator.userAgent,
+  })
+  const parsed = parseRpcUrl(rpc.url)
+  const out = file.relPath ? `${file.relPath}/${file.name}` : file.name
+  await sendAddUri(rpc.url, {
+    url,
+    out,
+    headers,
+    downloadPath: settings.downloadPath,
+    sha1: file.sha1,
+    sha1Check: settings.sha1Check,
+    fragmentOptions: parsed.options,
+  })
+  logger.info('pushFile', { name: file.name, rpc: rpc.name })
+}
+
+/** 推送文件夹，支持进度回调 */
+export async function pushFolder(input: {
+  cid: string
+  rootPath: string
+  rpc: Aria2RpcPreset
+  onListProgress?: (walked: number) => void
+  onPushProgress?: (done: number, total: number, failed: number) => void
+}): Promise<{ done: number, failed: number }> {
+  const settings = readSettings()
+  const files: Aria2FileEntry[] = []
+  let walked = 0
+  for await (const f of walkFolder(input.cid, input.rootPath, settings.intervalMs)) {
+    files.push(f)
+    walked++
+    input.onListProgress?.(walked)
+  }
+
+  let done = 0
+  let failed = 0
+  for (const f of files) {
+    try {
+      await pushFile(
+        {
+          pickCode: f.pickCode,
+          name: f.name,
+          relPath: f.relPath,
+          sha1: f.sha1,
+        },
+        input.rpc,
+      )
+      done++
+    }
+    catch (e) {
+      failed++
+      logger.warn('pushFolder: 单文件失败', { name: f.name, err: e })
+    }
+    input.onPushProgress?.(done, files.length, failed)
+    if (settings.intervalMs > 0) {
+      await new Promise(r => setTimeout(r, settings.intervalMs))
+    }
+  }
+  return { done, failed }
+}

--- a/apps/monkey/src/utils/aria2/rpc.ts
+++ b/apps/monkey/src/utils/aria2/rpc.ts
@@ -1,0 +1,132 @@
+import type { ParsedRpcUrl } from './types'
+import { GMRequest } from '@/utils/request/gmRequst'
+
+export function parseRpcUrl(raw: string): ParsedRpcUrl {
+  const u = new URL(raw)
+  const endpoint = `${u.origin}${u.pathname}`
+
+  let auth: ParsedRpcUrl['auth']
+  if (u.username) {
+    const pass = decodeURIComponent(u.password)
+    const full = `${u.username}:${pass}`
+    if (u.username === 'token') {
+      auth = { mode: 'token', token: full }
+    }
+    else {
+      auth = { mode: 'basic', header: `Basic ${btoa(full)}` }
+    }
+  }
+
+  const options: Record<string, string> = {}
+  if (u.hash.length > 1) {
+    const params = new URLSearchParams(u.hash.slice(1))
+    for (const [k, v] of params.entries()) {
+      options[k] = v.length ? v : 'enabled'
+    }
+  }
+
+  return { endpoint, auth, options }
+}
+
+export interface AddUriRequest {
+  url: string
+  out: string
+  headers: string[]
+  downloadPath: string
+  sha1?: string
+  sha1Check: boolean
+  fragmentOptions: Record<string, string>
+}
+
+export interface AddUriPayload {
+  jsonrpc: '2.0'
+  method: 'aria2.addUri'
+  id: number
+  params: unknown[]
+}
+
+export function buildAddUriPayload(
+  parsed: ParsedRpcUrl,
+  req: AddUriRequest,
+): AddUriPayload {
+  const options: Record<string, unknown> = {
+    out: req.out,
+    header: req.headers,
+    ...req.fragmentOptions,
+  }
+  if (req.downloadPath) {
+    options.dir = req.downloadPath
+  }
+  if (req.sha1Check && req.sha1) {
+    options.checksum = `sha-1=${req.sha1}`
+  }
+
+  const params: unknown[] = [[req.url], options]
+  if (parsed.auth?.mode === 'token') {
+    params.unshift(parsed.auth.token)
+  }
+
+  return {
+    jsonrpc: '2.0',
+    method: 'aria2.addUri',
+    id: Date.now(),
+    params,
+  }
+}
+
+const rpcRequest = new GMRequest({ cache: 'no-cache' }, 'aria2-rpc')
+
+async function postJsonRpc(
+  parsed: ParsedRpcUrl,
+  payload: unknown,
+): Promise<unknown> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (parsed.auth?.mode === 'basic') {
+    headers.Authorization = parsed.auth.header
+  }
+  const resp = await rpcRequest.request(parsed.endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+    timeout: 5000,
+  })
+  if (!resp.ok) {
+    throw new Error(`RPC HTTP ${resp.status}`)
+  }
+  const json = (await resp.json()) as {
+    result?: unknown
+    error?: { message: string }
+  }
+  if (json.error) {
+    throw new Error(`RPC error: ${json.error.message}`)
+  }
+  return json.result
+}
+
+export async function sendAddUri(
+  rpcUrl: string,
+  req: AddUriRequest,
+): Promise<string> {
+  const parsed = parseRpcUrl(rpcUrl)
+  const payload = buildAddUriPayload(parsed, req)
+  const result = await postJsonRpc(parsed, payload)
+  return String(result)
+}
+
+export async function getAria2Version(rpcUrl: string): Promise<string> {
+  const parsed = parseRpcUrl(rpcUrl)
+  const params: unknown[] = []
+  if (parsed.auth?.mode === 'token') {
+    params.push(parsed.auth.token)
+  }
+  const payload = {
+    jsonrpc: '2.0',
+    method: 'aria2.getVersion',
+    id: Date.now(),
+    params,
+  }
+  const result = (await postJsonRpc(parsed, payload)) as { version: string }
+  return result.version
+}

--- a/apps/monkey/src/utils/aria2/types.ts
+++ b/apps/monkey/src/utils/aria2/types.ts
@@ -1,0 +1,55 @@
+/** RPC 预设 */
+export interface Aria2RpcPreset {
+  /** 稳定 ID（nanoid） */
+  id: string
+  /** 显示名 */
+  name: string
+  /** 完整 URL，支持 http://token:secret@host:port/jsonrpc#k=v&k2=v2 */
+  url: string
+}
+
+/** Aria2 设置 */
+export interface Aria2Settings {
+  rpcList: Aria2RpcPreset[]
+  downloadPath: string
+  intervalMs: number
+  sha1Check: boolean
+  useBrowserUA: boolean
+  userAgent: string
+  referer: string
+  /** 每行一条 "Key: Value" */
+  extraHeaders: string
+}
+
+/** walker 产出的单个文件条目 */
+export interface Aria2FileEntry {
+  pickCode: string
+  name: string
+  /** 相对于起始目录的相对路径，根目录下的文件为 ''  */
+  relPath: string
+  /** 可选 SHA1（用于 checksum 校验） */
+  sha1?: string
+  /** 字节数 */
+  size?: number
+}
+
+/** RPC URL 解析结果 */
+export interface ParsedRpcUrl {
+  /** jsonrpc HTTP endpoint */
+  endpoint: string
+  /** token 模式：'token:xxx'；basic 模式：'Basic <base64>'；无认证：undefined */
+  auth: { mode: 'token', token: string } | { mode: 'basic', header: string } | undefined
+  /** URL fragment 解析的 options，例如 {split: '10', 'max-connection-per-server': '5'} */
+  options: Record<string, string>
+}
+
+export const ARIA2_DEFAULT_SETTINGS: Aria2Settings = {
+  rpcList: [],
+  downloadPath: '',
+  intervalMs: 300,
+  sha1Check: false,
+  useBrowserUA: true,
+  userAgent: '',
+  referer: 'https://115.com',
+  extraHeaders: '',
+}

--- a/apps/monkey/src/utils/aria2/walker.ts
+++ b/apps/monkey/src/utils/aria2/walker.ts
@@ -1,0 +1,96 @@
+import type { Aria2FileEntry } from './types'
+import { drive115 } from '@/utils/drive115'
+
+interface RawItem {
+  pc?: string
+  cid?: string
+  n: string
+  sha?: string
+  s?: number
+}
+
+async function fetchPage(cid: string, intervalMs: number): Promise<RawItem[]> {
+  if (!cid) {
+    throw new Error('walkFolder: cid 为空，无法获取目录')
+  }
+  /** 字段对齐 drive115 wrap.ts 中 getPlaylist 的参数，只改 show_dir 为 1 以拿到子目录 */
+  const params = {
+    aid: 1,
+    cid,
+    offset: 0,
+    limit: 1150,
+    show_dir: 1,
+    nf: '',
+    qid: 0,
+    type: 0,
+    source: '',
+    format: 'json',
+    star: '',
+    is_q: '',
+    is_share: '',
+    r_all: 1,
+    o: 'file_name',
+    asc: 1,
+    cur: 1,
+    natsort: 1,
+  }
+
+  // 带一次重试
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const resp = await drive115.getFiles(params as any)
+
+      return (((resp as any).data ?? []) as RawItem[])
+    }
+    catch (e) {
+      if (attempt === 1)
+        throw e
+      if (intervalMs > 0)
+        await new Promise(r => setTimeout(r, intervalMs))
+    }
+  }
+  return []
+}
+
+/**
+ * 递归遍历目录，逐个 yield 文件条目（深度优先 + 节流）
+ * @param cid 起始目录 cid
+ * @param rootPath 起始目录显示名，用作 relPath 前缀
+ * @param intervalMs 页之间的节流间隔
+ */
+export async function* walkFolder(
+  cid: string,
+  rootPath: string,
+  intervalMs: number,
+): AsyncGenerator<Aria2FileEntry> {
+  const stack: Array<{ cid: string, relPath: string }> = [
+    { cid, relPath: rootPath },
+  ]
+
+  while (stack.length > 0) {
+    const cur = stack.pop()!
+    const items = await fetchPage(cur.cid, intervalMs)
+
+    for (const item of items) {
+      if (item.sha) {
+        yield {
+          pickCode: String(item.pc),
+          name: item.n,
+          relPath: cur.relPath,
+          sha1: item.sha,
+          size: item.s,
+        }
+      }
+      else if (item.cid) {
+        stack.push({
+          cid: item.cid,
+          relPath: cur.relPath ? `${cur.relPath}/${item.n}` : item.n,
+        })
+      }
+    }
+
+    if (stack.length > 0 && intervalMs > 0) {
+      await new Promise(r => setTimeout(r, intervalMs))
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
+      nanoid:
+        specifier: ^5.1.9
+        version: 5.1.9
       photoswipe:
         specifier: ^5.4.4
         version: 5.4.4
@@ -782,79 +785,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -933,28 +923,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2272,28 +2258,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -2545,6 +2527,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -5853,6 +5840,8 @@ snapshots:
   nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.9: {}
 
   natural-compare@1.4.0: {}
 


### PR DESCRIPTION
## 背景

115 文件夹下载目前在脚本内直接 `alert('当前未支持文件夹下载')`（`FileItemMod/download.ts:39`），只能靠 115 原生下载且一次只能一个文件。本 PR 集成 aria2 JSON-RPC，补齐文件夹批量下载能力。

## 主要变更

在文件列表每行的 `.file-opr` 容器（即 115 原生下载按钮所在处）新增「推送 Aria2」按钮，按 RPC 预设数量自适应三种形态：

| RPC 预设数量 | 行内呈现 |
|---|---|
| 0 | `⚙ 配置 Aria2` — 引导打开设置面板 |
| 1 | `⇩ <预设名>` — 单按钮直接推送 |
| ≥2 | `⇩ Aria2 ▾` — hover 下拉选择 |

- **文件行**：点击后直接拿直链推给 aria2
- **文件夹行**：异步递归遍历子目录（`drive115.getFiles` 带 `show_dir=1`），批量推送所有文件，aria2 落盘时保留目录结构
- **推送时自动注入 Cookie / UA / Referer 到 aria2 headers**，下载端可通过 115 鉴权（否则 403）

## 设置面板

通过行内下拉的「⚙ 设置」项打开，持久化到 `GM_setValue('ARIA2_SETTINGS')`：

- RPC 列表（多预设，`名称` + `URL`，支持 `http://token:密钥@host:port/jsonrpc#k=v&k2=v2`，行内「测试」按钮调用 `aria2.getVersion` 回显版本）
- 下载路径、递归间隔、SHA1 校验
- UA（默认使用浏览器 UA，可自定义）、Referer、自定义 Headers（每行 `Key: Value`）

## 架构

```
apps/monkey/src/
├── utils/aria2/              # 纯逻辑层，无 Vue / DOM 依赖
│   ├── types.ts              # 类型定义 + 默认设置常量
│   ├── config.ts             # GM 持久化 + 发布订阅
│   ├── headers.ts            # 构造 aria2 addUri 的 header 数组
│   ├── rpc.ts                # RPC URL 解析 / addUri / getVersion
│   ├── walker.ts             # async generator 递归遍历目录
│   ├── events.ts             # mitt 事件总线
│   └── index.ts              # 对外 API：pushFile / pushFolder / testRpc
│
├── components/
│   ├── Aria2SettingsDialog/  # Vue 设置面板 + RPC 列表编辑子组件
│   └── MasterToast/          # 新增通用 toast 组件（info/success/error/loading）
│
└── pages/home/FileListMod/FileItemMod/
    └── aria2Push.ts          # 行内三态按钮 Mod
```

## 测试

`utils/aria2/` 为纯逻辑层，覆盖了单元测试（Vitest）：

| 被测模块 | 用例数 | 覆盖 |
|---|---:|---|
| `config.ts` | 5 | 读/写/订阅/取消订阅 |
| `headers.ts` | 5 | UA 切换、Referer/Cookie/自定义 Headers、空值过滤 |
| `rpc.ts` | 12 | URL 解析（无认证 / token / basic / fragment options），addUri payload 构造（token 前置、basic 不改、dir、checksum、fragment 合并） |
| `walker.ts` | 4 | 单层目录、嵌套目录、失败重试成功、失败两次抛出 |

全部通过：`pnpm --filter @115master/monkey test` → 36/36。

## 手动冒烟（本机）

1. `aria2c --enable-rpc --rpc-listen-all --rpc-secret=<密钥>`
2. 设置面板加 RPC：`http://token:<密钥>@localhost:6800/jsonrpc` → 点「测试」显示版本
3. 单文件行 → 点按钮 → aria2 面板出现任务，下载成功
4. 文件夹行 → toast 实时显示「正在获取文件列表 → 推送中 x/y → 已推送 N 个」，aria2 中每个任务的 `out` 含相对路径，目录结构保留
5. 配置 2 个 RPC → 按钮变下拉 → 不同预设分别推送
6. 关闭 aria2 → 推送时 toast 红色错误，控制台 `Aria2` logger 有堆栈

## 兼容性

- `is115Browser` 为 true 时不渲染（与现有 `FileItemModDownload` 一致，115 浏览器内置不走代理）
- 文件列表网格视图下不渲染（与现有 `FileItemModExtMenu` 一致）
- `userSettings` 没动，Aria2 配置持久化用独立 key `ARIA2_SETTINGS`

## Changeset

已随 PR 附上 `@115master/monkey` minor bump。

## 非目标 / 后续可选

- 顶部工具栏批量推送入口（v1 仅行内按钮）
- 文本导出（aria2c.down / IDM.ef2 / 纯链接 / 复制）
- 小文件优先排序
- walker 仅请求一页（`limit=1150`），超大目录后续可加分页